### PR TITLE
Feature/extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ public class BlogFilterDto : FilterBase<Blog>
 - Let's create a sample Controller and get the DTO from querystring
 
 ```csharp
+using AutoFilterer.Extensions; // <-- To call extension methods
+//...
 public class BlogsController : ControllerBase
 {
     [HttpGet]
@@ -70,7 +72,7 @@ public class BlogsController : ControllerBase
     {
         using(var db = new MyDbContext())
         {
-            var blogList = filter.ApplyFilterTo(db.Blogs).ToList();
+            var blogList = db.Blogs.ApplyFilter(filter);
             return Ok(blogList);
         }
     }
@@ -206,9 +208,8 @@ public class BlogsController : ControllerBase
     {
         using(var db = new MyDbContext())
         {
-            // You just need to apply an ordering before calling ApplyFilterTo() method
-            var query = db.Blogs.OrderByDescending(o => o.PublishDate);
-            var blogList = filter.ApplyFilterTo(query).ToList();
+            // You just need to apply an ordering before calling ApplyFilter() method
+            var blogList = db.Blogs.OrderBy(o => o.PublishDate).ApplyFilter(filter);
             return Ok(blogList);
         }
     }

--- a/sandbox/WebApplication.API/Controllers/BlogsController.cs
+++ b/sandbox/WebApplication.API/Controllers/BlogsController.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
+using AutoFilterer.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using WebApplication.API.Dtos;
+using WebApplication.API.Models;
 using WebApplication.API.Repository;
 
 namespace WebApplication.API.Controllers
@@ -14,21 +14,31 @@ namespace WebApplication.API.Controllers
     public class BlogsController : ControllerBase
     {
         // api/Blogs
-        // api/Blogs?page=1
-        // api/Blogs?page=2&perPage=4
         // api/Blogs?title=hello
         // api/Blogs?title=hello
         // api/Blogs?isPublished=False
         // api/Blogs?priority.min=2
-
         [HttpGet]
         public IActionResult Get([FromQuery]BlogFilterDto filter)
         {
             var db = new BlogDummyData();
 
-            var query = db.Blogs.OrderByDescending(o => o.PublishDate);
+            var list = db.Blogs.ApplyFilter(filter);
 
-            var list = filter.ApplyFilterTo(query).ToList();
+            return Ok(list);
+        }
+
+        // api/Blogs
+        // api/Blogs?page=1
+        // api/Blogs?page=2&perPage=4
+        // api/Blogs?title=hello
+        // api/Blogs?priority.min=5
+        [HttpGet("paged")]
+        public IActionResult GetWithPages(BlogPaginationFilterDto filter)
+        {
+            var db = new BlogDummyData();
+
+            var list = db.Blogs.OrderBy(o => o.PublishDate).ApplyFilter(filter);
 
             return Ok(list);
         }

--- a/sandbox/WebApplication.API/Dtos/BlogPaginationFilterDto.cs
+++ b/sandbox/WebApplication.API/Dtos/BlogPaginationFilterDto.cs
@@ -1,17 +1,15 @@
 ﻿using AutoFilterer.Attributes;
 using AutoFilterer.Enums;
 using AutoFilterer.Types;
-using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using WebApplication.API.Models;
 
 namespace WebApplication.API.Dtos
 {
-    public class BlogFilterDto : FilterBase<Blog>
+    public class BlogPaginationFilterDto : PaginationFilterBase
     {
         public int? CategoryId { get; set; }
 

--- a/src/AutoFilterer/Abstractions/IFilter.cs
+++ b/src/AutoFilterer/Abstractions/IFilter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoFilterer.Abstractions
+{
+    public interface IFilter : IFilterableType
+    {
+        IQueryable<TEntity> ApplyFilterTo<TEntity>(IQueryable<TEntity> query);
+    }
+}

--- a/src/AutoFilterer/Extensions/QueryExtensions.cs
+++ b/src/AutoFilterer/Extensions/QueryExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using AutoFilterer.Abstractions;
+using AutoFilterer.Types;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -27,5 +29,10 @@ namespace AutoFilterer.Extensions
 
             return (source as IOrderedQueryable<T>).Skip((page - 1) * pageSize).Take(pageSize);
         }
-    }
+
+        public static IQueryable<T> ApplyFilter<T>(this IQueryable<T> source, IFilter filter)
+        {
+            return filter.ApplyFilterTo(source);
+        }
+    } 
 }

--- a/src/AutoFilterer/Types/FilterBase.cs
+++ b/src/AutoFilterer/Types/FilterBase.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace AutoFilterer.Types
 {
-    public class FilterBase : IFilterableType
+    public class FilterBase : IFilter
     {
         /// <summary>
         /// Automaticly Applies Where() to IQuaryable collection. Please visit project site for more information and customizations.
@@ -77,17 +77,4 @@ namespace AutoFilterer.Types
             return Expression.Lambda<Func<TModel, bool>>(comparison, parameter);
         }
     }
-
-    public class FilterBase<TEntity> : FilterBase
-    {
-        /// <summary>
-        /// Automaticly Applies Where() to IQuaryable collection. Please visit project site for more information and customizations.
-        /// </summary>
-        /// <param name="query"></param>
-        public virtual IQueryable<TEntity> ApplyFilterTo(IQueryable<TEntity> query)
-        {
-            return ApplyFilterTo<TEntity>(query);
-        }
-    }
-
 }

--- a/src/AutoFilterer/Types/FilterBase{TEntity}.cs
+++ b/src/AutoFilterer/Types/FilterBase{TEntity}.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoFilterer.Types
+{
+    /// <summary>
+    /// Base class of filter Data Transfer Objects (DTO).
+    /// If you don't have access to your Entity models from dto (if they're in seperated libraries), just inherit non-generic type of FilterBase which is <see cref="FilterBase"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Entity Type.</typeparam>
+    public class FilterBase<TEntity> : FilterBase
+    {
+        /// <summary>
+        /// Automaticly Applies Where() to IQuaryable collection. Please visit project site for more information and customizations.
+        /// </summary>
+        /// <param name="query"></param>
+        public virtual IQueryable<TEntity> ApplyFilterTo(IQueryable<TEntity> query)
+        {
+            return ApplyFilterTo<TEntity>(query);
+        }
+    }
+}

--- a/src/AutoFilterer/Types/Range.cs
+++ b/src/AutoFilterer/Types/Range.cs
@@ -12,8 +12,8 @@ namespace AutoFilterer.Types
     {
         public Range()
         {
-
         }
+
         public Range(string value)
         {
             var parsed = Parse<T>(value);
@@ -104,7 +104,7 @@ namespace AutoFilterer.Types
                     maxValue = ulong.MaxValue;
                     break;
                 default:
-                    maxValue = default(T1);//set default value
+                    maxValue = default(T1); // Set as default value.
                     break;
             }
             return (T1)maxValue;


### PR DESCRIPTION
That PR aims improve developer usage experience with `ApplyFilter()` extension method on `IQueryable<T>` types _(like: DbSet<T>)_.

So view changes of usage:

-from:

```csharp
filter.ApplyFilterTo(db.Blogs);
```
- to

```csharp
db.Blogs.ApplyFilter(filter);
```

So developers can continue to use fluent api usage of LINQ as customary.