### PR TITLE
Add Multi-Targeting Feature

### DIFF
--- a/src/AutoFilterer/Abstractions/IFilterableType.cs
+++ b/src/AutoFilterer/Abstractions/IFilterableType.cs
@@ -6,6 +6,6 @@ namespace AutoFilterer.Abstractions
 {
     public interface IFilterableType
     {
-        Expression BuildExpression(Expression expressionBody, PropertyInfo property, object value);
+        Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value);
     }
 }

--- a/src/AutoFilterer/Attributes/CollectionFilterAttribute.cs
+++ b/src/AutoFilterer/Attributes/CollectionFilterAttribute.cs
@@ -1,0 +1,46 @@
+﻿using AutoFilterer.Abstractions;
+using AutoFilterer.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoFilterer.Attributes
+{
+    public class CollectionFilterAttribute : FilteringOptionsBaseAttribute
+    {
+        public CollectionFilterAttribute()
+        {
+        }
+
+        public CollectionFilterAttribute(CollectionFilterType filterOption)
+        {
+            this.FilterOption = filterOption;
+        }
+
+        public CollectionFilterType FilterOption { get; set; }
+
+        public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+        {
+            if (value is IFilter filter)
+            {
+                var type = targetProperty.PropertyType.GetGenericArguments().FirstOrDefault();
+                var parameter = Expression.Parameter(type, "a");
+                var innerLambda = Expression.Lambda(filter.BuildExpression(type, body: parameter), parameter);
+                var prop = Expression.Property(expressionBody, targetProperty.Name);
+                var methodInfo = typeof(Enumerable).GetMethods().LastOrDefault(x => x.Name == FilterOption.ToString());
+                var method = methodInfo.MakeGenericMethod(type);
+
+                expressionBody = Expression.Call(
+                                            method: method,
+                                            instance: null,
+                                            arguments: new Expression[] { prop, innerLambda }
+                    );
+            }
+            return expressionBody;
+        }
+    }
+}

--- a/src/AutoFilterer/Attributes/CompareToAttribute.cs
+++ b/src/AutoFilterer/Attributes/CompareToAttribute.cs
@@ -1,0 +1,75 @@
+﻿using AutoFilterer.Abstractions;
+using AutoFilterer.Enums;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoFilterer.Attributes
+{
+    public class CompareToAttribute : FilteringOptionsBaseAttribute
+    {
+        public CompareToAttribute(params string[] propertyNames)
+        {
+            PropertyNames = propertyNames;
+        }
+
+        public string[] PropertyNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets CombineType parameter. All properties are combined with 'Or' by default.
+        /// </summary>
+        public CombineType CombineWith { get; set; } = CombineType.Or;
+
+        public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+        {
+            for (int i = 0; i < PropertyNames.Length; i++)
+            {
+                var targetPropertyName = PropertyNames[i];
+                var _targetProperty = targetProperty.DeclaringType.GetProperty(targetPropertyName);
+
+                expressionBody = BuildExpressionForProperty(expressionBody, _targetProperty, filterProperty, value);
+            }
+
+            return expressionBody;
+        }
+
+        public virtual Expression BuildExpressionForProperty(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+        {
+            var attribute = filterProperty.GetCustomAttributes<FilteringOptionsBaseAttribute>().FirstOrDefault(x => !(x is CompareToAttribute));
+
+            if (attribute != null)
+            {
+                return attribute.BuildExpression(expressionBody, targetProperty, filterProperty, value);
+            }
+
+            if (value is IFilter filter)
+            {
+                if (typeof(ICollection).IsAssignableFrom(targetProperty.PropertyType) || (targetProperty.PropertyType.IsConstructedGenericType && typeof(IEnumerable).IsAssignableFrom(targetProperty.PropertyType)))
+                {
+                    var collectionAttribute = new CollectionFilterAttribute();
+                    return collectionAttribute.BuildExpression(expressionBody, targetProperty, filterProperty, value);
+                }
+                else
+                {
+                    var parameter = Expression.Property(expressionBody, targetProperty.Name);
+                    return filter.BuildExpression(targetProperty.PropertyType, parameter);
+                }
+            }
+
+            if (value is IFilterableType filterableProperty)
+            {
+                return filterableProperty.BuildExpression(expressionBody, targetProperty, filterProperty, value);
+            }
+            else
+            {
+                return new OperatorComparisonAttribute(OperatorType.Equal).BuildExpression(expressionBody, targetProperty, filterProperty, value);
+            }
+        }
+    }
+}

--- a/src/AutoFilterer/Attributes/FilteringOptionsBaseAttribute.cs
+++ b/src/AutoFilterer/Attributes/FilteringOptionsBaseAttribute.cs
@@ -1,17 +1,13 @@
 ﻿using AutoFilterer.Abstractions;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AutoFilterer.Attributes
 {
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public abstract class FilteringOptionsBaseAttribute : Attribute, IFilterableType
     {
-        public abstract Expression BuildExpression(Expression expressionBody, PropertyInfo property, object value);
+        public abstract Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty , object value);
     }
 }

--- a/src/AutoFilterer/Attributes/IgnoreFilterAttribute.cs
+++ b/src/AutoFilterer/Attributes/IgnoreFilterAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoFilterer.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    sealed class IgnoreFilterAttribute : FilteringOptionsBaseAttribute
+    {
+        public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+        {
+            return expressionBody;
+        }
+    }
+}

--- a/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
+++ b/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
@@ -1,9 +1,11 @@
 ﻿using AutoFilterer.Enums;
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
 
 namespace AutoFilterer.Attributes
 {
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public class OperatorComparisonAttribute : FilteringOptionsBaseAttribute
     {
         public OperatorComparisonAttribute(OperatorType operatorType)
@@ -13,9 +15,9 @@ namespace AutoFilterer.Attributes
 
         public OperatorType OperatorType { get; }
 
-        public override Expression BuildExpression(Expression expressionBody, PropertyInfo property, object value)
+        public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
         {
-            var prop = Expression.Property(expressionBody, property.Name);
+            var prop = Expression.Property(expressionBody, targetProperty.Name);
             var param = Expression.Constant(value);
 
             switch (OperatorType)

--- a/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
+++ b/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
@@ -27,12 +27,12 @@ namespace AutoFilterer.Attributes
 
         public StringComparison? Comparison { get; set; }
 
-        public override Expression BuildExpression(Expression expressionBody, PropertyInfo property, object value)
+        public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
         {
             if (Comparison == null)
-                return BuildExpressionWithoutComparison(this.Option, expressionBody, property, value);
+                return BuildExpressionWithoutComparison(this.Option, expressionBody, targetProperty, value);
             else
-                return BuildExpressionWithComparison(this.Option, expressionBody, property, value);
+                return BuildExpressionWithComparison(this.Option, expressionBody, targetProperty, value);
         }
 
         private Expression BuildExpressionWithComparison(StringFilterOption option, Expression expressionBody, PropertyInfo property, object value)

--- a/src/AutoFilterer/AutoFilterer.csproj
+++ b/src/AutoFilterer/AutoFilterer.csproj
@@ -9,10 +9,10 @@
     <RepositoryUrl>https://github.com/enisn/AutoFilterer</RepositoryUrl>
     <PackageTags>netstandard, EntityFramework, netcore, aspnetcore, auto filter, filtering</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>1.3.0</Version>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <Version>2.0.0-pre.1</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <PackageReleaseNotes>Added missing virtual keyword, Now it can be more overridable!</PackageReleaseNotes>
-    <FileVersion>1.3.0.0</FileVersion>
+    <FileVersion>2.0.0.0</FileVersion>
     <PackageIconUrl>https://raw.githubusercontent.com/enisn/AutoFilterer/master/content/auto_filterer_icon.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/src/AutoFilterer/Enums/CollectionFilterType.cs
+++ b/src/AutoFilterer/Enums/CollectionFilterType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace AutoFilterer.Enums
+{
+    [Flags]
+    public enum CollectionFilterType
+    {
+        Any,
+        All,
+    }
+}

--- a/src/AutoFilterer/Types/Range.cs
+++ b/src/AutoFilterer/Types/Range.cs
@@ -56,7 +56,7 @@ namespace AutoFilterer.Types
             return $"{this.Min?.ToString() ?? "-"} {this.Max?.ToString() ?? "-"}";
         }
 
-        public Expression BuildExpression(Expression body, PropertyInfo property, object value)
+        public Expression BuildExpression(Expression body, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
         {
             return GetRangeComparison();
 
@@ -67,7 +67,7 @@ namespace AutoFilterer.Types
                 if (Min != null)
                 {
                     minExp = Expression.GreaterThanOrEqual(
-                               Expression.Property(body, property.Name),
+                               Expression.Property(body, targetProperty.Name),
                                Expression.Constant(Min));
                     if (Max == null)
                         return minExp;
@@ -76,7 +76,7 @@ namespace AutoFilterer.Types
                 if (Max != null)
                 {
                     maxExp = Expression.LessThanOrEqual(
-                                Expression.Property(body, property.Name),
+                                Expression.Property(body, targetProperty.Name),
                                 Expression.Constant(Max));
                     if (Min == null)
                         return maxExp;

--- a/tests/AutoFilterer.Tests/Attributes/CompareToAttributeTests.cs
+++ b/tests/AutoFilterer.Tests/Attributes/CompareToAttributeTests.cs
@@ -1,0 +1,59 @@
+﻿using AutoFilterer.Tests.Envirorment.Dtos;
+using AutoFilterer.Tests.Envirorment.Models;
+using AutoFilterer.Tests.Envirorment.Statics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using AutoFilterer.Extensions;
+
+namespace AutoFilterer.Tests.Attributes
+{
+    public class CompareToAttributeTests
+    {
+        [Theory, AutoMoqData(count: 64)]
+        public void BuildExpression_MultipleFieldWithOr_ShouldMatchCount(List<Book> dummyData)
+        {
+            // Arrange
+            var filter = new BookFilter_MultiplePropertyWithOrDto
+            {
+                CombineWith = Enums.CombineType.Or,
+                Query = "12"
+            };
+
+            IQueryable<Book> query = dummyData.AsQueryable();
+
+            // Act
+            var result = query.ApplyFilter(filter).ToList();
+
+            // Assert
+            var actualResult = query.Where(x => x.Title.Contains(filter.Query) || x.Author.Contains(filter.Query)).ToList();
+
+            Assert.Equal(result.Count, actualResult.Count);
+        }
+
+        [Theory, AutoMoqData(count: 64)]
+        public void BuildExpression_MultipleFieldWithAnd_ShouldMatchCount(List<Book> dummyData)
+        {
+            // Arrange
+            var filter = new BookFilter_MultiplePropertyWithAndDto
+            {
+                CombineWith = Enums.CombineType.Or,
+                Query = "a"
+            };
+
+            IQueryable<Book> query = dummyData.AsQueryable();
+
+            // Act
+            var filteredQuery = query.ApplyFilter(filter);
+            Console.WriteLine(filteredQuery);
+            var result = filteredQuery.ToList();
+
+            // Assert
+            var actualResult = query.Where(x => x.Title.Contains(filter.Query) && x.Author.Contains(filter.Query)).ToList();
+            Assert.Equal(result.Count, actualResult.Count);
+        }
+    }
+}

--- a/tests/AutoFilterer.Tests/Envirorment/Dtos/BookFilterBase.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Dtos/BookFilterBase.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AutoFilterer.Tests.Dtos
+namespace AutoFilterer.Tests.Envirorment.Dtos
 {
     public class BookFilterBase : FilterBase
     {

--- a/tests/AutoFilterer.Tests/Envirorment/Dtos/BookFilter_MultiplePropertyWithAndDto.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Dtos/BookFilter_MultiplePropertyWithAndDto.cs
@@ -1,0 +1,13 @@
+﻿using AutoFilterer.Attributes;
+using AutoFilterer.Tests.Envirorment.Models;
+using AutoFilterer.Types;
+
+namespace AutoFilterer.Tests.Envirorment.Dtos
+{
+    public class BookFilter_MultiplePropertyWithAndDto : FilterBase
+    {
+        [CompareTo(nameof(Book.Title), nameof(Book.Author), CombineWith = Enums.CombineType.And)]
+        [StringFilterOptions(Enums.StringFilterOption.Contains)]
+        public string Query { get; set; }
+    }
+}

--- a/tests/AutoFilterer.Tests/Envirorment/Dtos/BookFilter_MultiplePropertyWithOrDto.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Dtos/BookFilter_MultiplePropertyWithOrDto.cs
@@ -1,0 +1,18 @@
+﻿using AutoFilterer.Attributes;
+using AutoFilterer.Tests.Envirorment.Models;
+using AutoFilterer.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoFilterer.Tests.Envirorment.Dtos
+{
+    public class BookFilter_MultiplePropertyWithOrDto : FilterBase
+    {
+        [CompareTo(nameof(Book.Title), nameof(Book.Author), CombineWith = Enums.CombineType.Or)]
+        [StringFilterOptions(Enums.StringFilterOption.Contains)]
+        public string Query { get; set; }
+    }
+}

--- a/tests/AutoFilterer.Tests/Envirorment/Dtos/PreferencesFilterBase.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Dtos/PreferencesFilterBase.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AutoFilterer.Tests.Dtos
+namespace AutoFilterer.Tests.Envirorment.Dtos
 {
     public class PreferencesFilterBase : FilterBase
     {

--- a/tests/AutoFilterer.Tests/Envirorment/Dtos/UserFilterBase.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Dtos/UserFilterBase.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AutoFilterer.Tests.Dtos
+namespace AutoFilterer.Tests.Envirorment.Dtos
 {
     public class UserFilterBase : FilterBase
     {

--- a/tests/AutoFilterer.Tests/Envirorment/Models/Book.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Models/Book.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AutoFilterer.Tests.Models
+namespace AutoFilterer.Tests.Envirorment.Models
 {
     public class Book
     {

--- a/tests/AutoFilterer.Tests/Envirorment/Models/Preferences.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Models/Preferences.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AutoFilterer.Tests.Models
+namespace AutoFilterer.Tests.Envirorment.Models
 {
     public class Preferences
     {

--- a/tests/AutoFilterer.Tests/Envirorment/Models/User.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Models/User.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AutoFilterer.Tests.Models
+namespace AutoFilterer.Tests.Envirorment.Models
 {
     public class User
     {

--- a/tests/AutoFilterer.Tests/Envirorment/Statics/AutoMoqDataAttribute.cs
+++ b/tests/AutoFilterer.Tests/Envirorment/Statics/AutoMoqDataAttribute.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AutoFilterer.Tests.Statics
+namespace AutoFilterer.Tests.Envirorment.Statics
 {
     public class AutoMoqDataAttribute : AutoDataAttribute
     {

--- a/tests/AutoFilterer.Tests/Types/FilterBaseTests.cs
+++ b/tests/AutoFilterer.Tests/Types/FilterBaseTests.cs
@@ -1,16 +1,13 @@
-﻿using AutoFilterer.Tests.Dtos;
-using AutoFilterer.Tests.Models;
+﻿using AutoFilterer.Extensions;
+using AutoFilterer.Tests.Envirorment.Dtos;
+using AutoFilterer.Tests.Envirorment.Models;
+using AutoFilterer.Tests.Envirorment.Statics;
 using AutoFilterer.Types;
 using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using AutoFilterer.Extensions;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
-using System.Linq.Expressions;
-using AutoFilterer.Tests.Statics;
 
 namespace AutoFilterer.Tests.Types
 {
@@ -126,6 +123,7 @@ namespace AutoFilterer.Tests.Types
             IQueryable<User> query = dummyData.AsQueryable();
 
             // Act
+            filterBase.CombineWith = Enums.CombineType.And;
             var result = query.ApplyFilter(filterBase).ToList();
             filterBase.CombineWith = Enums.CombineType.Or;
             var orResult = query.ApplyFilter(filterBase).ToList();
@@ -195,7 +193,8 @@ namespace AutoFilterer.Tests.Types
             var query = dummyData.AsQueryable();
 
             // Act
-            var result = query.ApplyFilter(filterBase).ToList();
+            var filteredQuery = query.ApplyFilter(filterBase);
+            var result = filteredQuery.ToList();
 
             // Assert
             var actualResult = dummyData.Where(x => x.Preferences.GivenName.EndsWith(filterBase.Preferences.GivenName)).ToList();
@@ -218,7 +217,9 @@ namespace AutoFilterer.Tests.Types
             var query = dummyData.AsQueryable();
 
             // Act
-            var result = query.ApplyFilter(filter).ToList();
+            var filteredQuery = query.ApplyFilter(filter);
+            Console.WriteLine(filteredQuery);
+            var result = filteredQuery.ToList();
 
             // Assert
             var actualResult = dummyData.Where(x => x.Books.Any(a => a.Title.Contains(filter.Books.Title, StringComparison.InvariantCultureIgnoreCase))).ToList();


### PR DESCRIPTION
# Changes
- FilterBase logic is changed,
Filterbase now iterates filter object properties instead of target object properties. That provides a little bit performance while generating queries.
- Moved all things into CompareToAttribute
CompareToAttribute includes PropertyNames field in.
- Added IgnoreFilterAttribute
That ignores properties in filtering
- Added CollectionFilterAttribute
This allows to use Any or All method over collections. Much more options will come into this property.
- Updated IFilterableType interfaace
Added filterProperty parameter into BuildExpression method and seperated targetProperty and filterProperty.

# Sample
- Now Property name/names can be defined via `CompareTo` attribute:

```csharp
public class BookFilter : FilterBase
{
    [CompareTo("Title","Author")]
    [StringFilterOptions(StringFilterOption.Contains)]
    public string Search { get; set; }
}
```
