### PR TITLE
✨ Add LowerContains support for string fields.

### DIFF
--- a/sandbox/WebApplication.API/Dtos/BookFilter.cs
+++ b/sandbox/WebApplication.API/Dtos/BookFilter.cs
@@ -21,7 +21,8 @@ namespace WebApplication.API.Dtos
         [StringFilterOptions(StringFilterOption.Contains)]
         public string Language { get; set; }
 
-        public StringFilter Author { get; set; }
+        [ToLowerContainsComparison]
+        public string Author { get; set; }
 
         public OperatorFilter<int> TotalPage { get; set; }
 

--- a/src/AutoFilterer/Attributes/ToLowerContainsComparisonAttribute.cs
+++ b/src/AutoFilterer/Attributes/ToLowerContainsComparisonAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace AutoFilterer.Attributes
+{
+    /// <summary>
+    /// This class generates contains query, for string fields.
+    /// </summary>
+    public class ToLowerContainsComparisonAttribute : FilteringOptionsBaseAttribute
+    {
+        public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+        {
+            var containsMethod = typeof(string).GetMethod(nameof(string.Contains), types: new[] { typeof(string) });
+
+            var toLowerMethod = typeof(string).GetMethod(nameof(string.ToLower), types: new Type[0]);
+
+            var comparison = Expression.Equal(
+                        Expression.Call(
+                            method: containsMethod,
+                            instance: Expression.Call(method: toLowerMethod, instance: Expression.Property(expressionBody, targetProperty.Name)
+                                ),
+                            arguments: new[] { Expression.Call(method: toLowerMethod, instance: Expression.Constant(value)) }),
+                        Expression.Constant(true));
+
+            return comparison;
+        }
+    }
+}

--- a/tests/AutoFilterer.Tests/Attributes/ToLowerContainsComparisonAttributeTests.cs
+++ b/tests/AutoFilterer.Tests/Attributes/ToLowerContainsComparisonAttributeTests.cs
@@ -1,0 +1,34 @@
+﻿using AutoFilterer.Tests.Environment.Dtos;
+using AutoFilterer.Tests.Environment.Models;
+using AutoFilterer.Tests.Environment.Statics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using AutoFilterer.Extensions;
+
+namespace AutoFilterer.Tests.Attributes
+{
+    public class ToLowerContainsComparisonAttributeTests
+    {
+        [Theory, AutoMoqData]
+        public void BuildExpression_ShouldGenerateQueryCorrect_WithoutAttribute(List<Book> dummyData)
+        {
+            // Arrange
+            var filter = new BookFilter_LowerContains
+            {
+                Query = "a"
+            };
+            IQueryable<Book> query = dummyData.AsQueryable();
+
+            // Act
+            var filteredQuery = query.ApplyFilter(filter);
+            var result = filteredQuery.ToList();
+            // Assert
+            var actualResult = query.Where(x => x.Title.Contains(filter.Query.ToLower())).ToList();
+
+            Assert.Equal(result.Count, actualResult.Count);
+        }
+    }
+}

--- a/tests/AutoFilterer.Tests/Environment/Dtos/BookFilter_LowerContains.cs
+++ b/tests/AutoFilterer.Tests/Environment/Dtos/BookFilter_LowerContains.cs
@@ -1,0 +1,14 @@
+﻿using AutoFilterer.Attributes;
+using AutoFilterer.Types;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AutoFilterer.Tests.Environment.Dtos
+{
+    public class BookFilter_LowerContains : FilterBase
+    {
+        [ToLowerContainsComparison]
+        public string Query { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
This PR includes;
✨ This class generates contains query, for string fields.

## For Example

```csharp
        [ToLowerContainsComparison]
        public string Name { get; set; }
```

- Generated Query is:
```csharp
.Where(x => x.Name.ToLower().Contains(filter.Name.ToLower()))
```