### PR TITLE
✨Add ToLowerContains attribute for string fields

### DIFF
--- a/src/AutoFilterer.Generators/FilterGenerator.cs
+++ b/src/AutoFilterer.Generators/FilterGenerator.cs
@@ -84,6 +84,10 @@ namespace {@namespace ?? "AutoFilterer.Filters"}
                 if (TypeMapping.Mappings.TryGetValue(propertyType, out var mapped))
                     propertyType = mapped;
 
+                if (propertyType == "string")
+                {
+                    body.AppendLine("\t\t[ToLowerContainsComparison]");
+                }
                 body.AppendLine($"\t\tpublic virtual {propertyType} {property.Name} {{ get; set; }}");
             }
 

--- a/src/AutoFilterer.Generators/FilterGenerator.cs
+++ b/src/AutoFilterer.Generators/FilterGenerator.cs
@@ -84,7 +84,7 @@ namespace {@namespace ?? "AutoFilterer.Filters"}
                 if (TypeMapping.Mappings.TryGetValue(propertyType, out var mapped))
                     propertyType = mapped;
 
-                if (propertyType == "string")
+                if (propertyType.Equals(nameof(String), StringComparison.InvariantCultureIgnoreCase))
                 {
                     body.AppendLine("\t\t[ToLowerContainsComparison]");
                 }

--- a/tests/AutoFilterer.Generators.Tests/FilterGeneratorTests.cs
+++ b/tests/AutoFilterer.Generators.Tests/FilterGeneratorTests.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AutoFilterer.Attributes;
 using AutoFilterer.Enums;
+using Castle.Core.Internal;
 using Xunit;
 
 namespace AutoFilterer.Generators.Tests
@@ -102,6 +104,23 @@ namespace AutoFilterer.Generators.Tests
             Assert.NotNull(typeof(MappingTest.AllTypesTestTypeFilter));
             
             var filter = new MappingTest.AllTypesTestTypeFilter();
+        }
+        
+        [GenerateAutoFilter("MappingTest")]
+        public class StringAttributeTestType
+        {
+            public string Title { get; set; }
+        }
+
+        [Fact]
+        public void ShouldHaveToLowerContainsComparisonAttribute()
+        {
+            var attribute = 
+                typeof(MappingTest.StringAttributeTestTypeFilter)
+                .GetProperty(nameof(MappingTest.StringAttributeTestTypeFilter.Title))
+                .GetAttribute<ToLowerContainsComparisonAttribute>();
+            
+            Assert.NotNull(attribute);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR includes adding the `[ToLowerContainsComparison]` attribute to string fields of auto-generated filter objects by **AutoFilterer.Generators**