### PR TITLE
✨ Introduce multiple CompareTo attribute with IFilterableType

### DIFF
--- a/src/AutoFilterer/Attributes/CompareToAttribute.cs
+++ b/src/AutoFilterer/Attributes/CompareToAttribute.cs
@@ -73,7 +73,7 @@ namespace AutoFilterer.Attributes
         {
             if (FilterableType != null)
             {
-                return ((IFilterableType) Activator.CreateInstance(FilterableType)).BuildExpression(expressionBody, targetProperty, filterProperty, value);
+                return ((IFilterableType)Activator.CreateInstance(FilterableType)).BuildExpression(expressionBody, targetProperty, filterProperty, value);
             }
 
             var attribute = filterProperty.GetCustomAttributes<FilteringOptionsBaseAttribute>().FirstOrDefault(x => !(x is CompareToAttribute));
@@ -83,6 +83,11 @@ namespace AutoFilterer.Attributes
                 return attribute.BuildExpression(expressionBody, targetProperty, filterProperty, value);
             }
 
+            return BuildDefaultExpression(expressionBody, targetProperty, filterProperty, value);
+        }
+
+        public virtual Expression BuildDefaultExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+        {
             if (value is IFilter filter)
             {
                 if (typeof(ICollection).IsAssignableFrom(targetProperty.PropertyType) || (targetProperty.PropertyType.IsConstructedGenericType && typeof(IEnumerable).IsAssignableFrom(targetProperty.PropertyType)))

--- a/src/AutoFilterer/Attributes/CompareToAttribute.cs
+++ b/src/AutoFilterer/Attributes/CompareToAttribute.cs
@@ -6,13 +6,23 @@ using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System;
 
 namespace AutoFilterer.Attributes
 {
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
     public class CompareToAttribute : FilteringOptionsBaseAttribute
     {
+        private Type filterableType;
+
         public CompareToAttribute(params string[] propertyNames)
         {
+            PropertyNames = propertyNames;
+        }
+
+        public CompareToAttribute(Type filterableType, params string[] propertyNames)
+        {
+            FilterableType = filterableType;
             PropertyNames = propertyNames;
         }
 
@@ -23,14 +33,37 @@ namespace AutoFilterer.Attributes
         /// </summary>
         public CombineType CombineWith { get; set; } = CombineType.Or;
 
+        /// <summary>
+        /// Type must implement <see cref="IFilterableType"/> and must has parameterless constructor.
+        /// </summary>
+        public Type FilterableType
+        {
+            get => filterableType;
+            set
+            {
+                if (!typeof(IFilterableType).IsAssignableFrom(value))
+                {
+                    throw new ArgumentException($"The {value.FullName} type must implement 'IFilterableType'", nameof(FilterableType));
+                }
+
+                filterableType = value;
+            }
+        }
+
         public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
         {
             for (int i = 0; i < PropertyNames.Length; i++)
             {
                 var targetPropertyName = PropertyNames[i];
                 var _targetProperty = targetProperty.DeclaringType.GetProperty(targetPropertyName);
-
-                expressionBody = BuildExpressionForProperty(expressionBody, _targetProperty, filterProperty, value);
+                if (FilterableType != null)
+                {
+                    expressionBody = ((IFilterableType)Activator.CreateInstance(FilterableType)).BuildExpression(expressionBody, _targetProperty, filterProperty, value);
+                }
+                else
+                {
+                    expressionBody = BuildExpressionForProperty(expressionBody, _targetProperty, filterProperty, value);
+                }
             }
 
             return expressionBody;
@@ -38,6 +71,11 @@ namespace AutoFilterer.Attributes
 
         public virtual Expression BuildExpressionForProperty(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
         {
+            if (FilterableType != null)
+            {
+                return ((IFilterableType) Activator.CreateInstance(FilterableType)).BuildExpression(expressionBody, targetProperty, filterProperty, value);
+            }
+
             var attribute = filterProperty.GetCustomAttributes<FilteringOptionsBaseAttribute>().FirstOrDefault(x => !(x is CompareToAttribute));
 
             if (attribute != null)

--- a/src/AutoFilterer/AutoFiltererConsts.cs
+++ b/src/AutoFilterer/AutoFiltererConsts.cs
@@ -9,7 +9,6 @@ namespace AutoFilterer
             set
             {
                 FilterBase.IgnoreExceptions = value;
-                
             }
         }
     }

--- a/src/AutoFilterer/AutoFiltererConsts.cs
+++ b/src/AutoFilterer/AutoFiltererConsts.cs
@@ -1,0 +1,16 @@
+﻿using AutoFilterer.Types;
+
+namespace AutoFilterer
+{
+    public static class AutoFiltererConsts
+    {
+        public static bool IgnoreExceptions
+        {
+            set
+            {
+                FilterBase.IgnoreExceptions = value;
+                
+            }
+        }
+    }
+}

--- a/tests/AutoFilterer.Tests/Environment/Models/Book.cs
+++ b/tests/AutoFilterer.Tests/Environment/Models/Book.cs
@@ -15,5 +15,10 @@ namespace AutoFilterer.Tests.Environment.Models
         public int ReadCount { get; set; }
         public bool IsPublished { get; set; }
         public int? Views { get; set; }
+
+        public override string ToString()
+        {
+            return $"[{Id}] {Title} - {Author} | TotalPage: {TotalPage} | ReadCount: {ReadCount}";
+        }
     }
 }


### PR DESCRIPTION
## Introduce Multiple CompareTo Attribute
**CompareTo** attribute can be placed more than once over a property. Also you can pass a `ÌFilterableType` type  parameter to define which comparison should be applied.

### Example
You can do something like that:

```csharp
public class MultipleTypeCompareToAndComparisonFilter : FilterBase
{
    [CompareTo(typeof(ToLowerContainsComparisonAttribute), nameof(Book.Title))]
    [CompareTo(typeof(EndsWithAttribute), nameof(Book.Author), CombineWith = CombineType.And)]
    public string Search { get; set; }

    public class EndsWithAttribute : StringFilterOptionsAttribute
    {
        public EndsWithAttribute() : base(StringFilterOption.EndsWith, StringComparison.InvariantCultureIgnoreCase)
        {
        }
    }
}
```

This query will create something like that:
```csharp
db.Books.Where(x =>
                    x.Title.ToLower().Contains(filter.Search.ToLower())
                    && x.Author.EndsWith(filter.Search, StringComparison.InvariantCultureIgnoreCase));
```
