### PR TITLE
♻️Use singleton instances of attributes

### DIFF
--- a/docs/Benchmark-Results.md
+++ b/docs/Benchmark-Results.md
@@ -1,22 +1,20 @@
 ``` ini
-BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.1083 (20H2/October2020Update)
+
+BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22000
 Intel Core i7-10750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
-.NET SDK=6.0.100-preview.5.21302.13
-  [Host]     : .NET 5.0.7 (5.0.721.25508), X64 RyuJIT
-  DefaultJob : .NET 5.0.7 (5.0.721.25508), X64 RyuJIT
+.NET SDK=6.0.100
+  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
+  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
 
 
 ```
-
-| Method                            |      Mean |     Error |    StdDev | Completed Work Items |  Gen 0 |  Gen 1 | Gen 2 | Allocated | Code Size |
-| --------------------------------- | --------: | --------: | --------: | -------------------: | -----: | -----: | ----: | --------: | --------: |
-| EqualsSingleProperly_Lambda       |  3.184 μs | 0.0153 μs | 0.0144 μs |               0.0000 | 0.2861 |      - |     - |      2 KB |      3 KB |
-| EqualsSingleProperly_AutoFilterer |  8.348 μs | 0.0576 μs | 0.0539 μs |               0.0000 | 0.6409 |      - |     - |      4 KB |      0 KB |
-| StringFilter_Lambda               | 26.384 μs | 0.1595 μs | 0.1414 μs |               0.0001 | 2.4414 | 0.0305 |     - |     15 KB |     23 KB |
-| StringFilter_AutoFilterer         | 14.163 μs | 0.1540 μs | 0.1440 μs |               0.0000 | 1.0681 |      - |     - |      7 KB |      0 KB |
-| MinAndMax_Lambda                  |  5.176 μs | 0.0661 μs | 0.0586 μs |               0.0000 | 0.4501 |      - |     - |      3 KB |      7 KB |
-| MinAndMax_AutoFilterer            |  8.756 μs | 0.0653 μs | 0.0579 μs |               0.0000 | 0.6561 |      - |     - |      4 KB |      0 KB |
-| ComplexFilter_Lambda              | 18.311 μs | 0.1326 μs | 0.1175 μs |               0.0001 | 1.5259 |      - |     - |      9 KB |     14 KB |
-| ComplexFilter_AutoFilterer        | 25.776 μs | 0.1496 μs | 0.1399 μs |               0.0001 | 2.1057 |      - |     - |     13 KB |      0 KB |
-
-- You can find benchmark test methods source codes from [here](https://github.com/enisn/AutoFilterer/blob/develop/tests/AutoFilterer.Benchmark/AutoFiltererStartup.cs). 
+|                            Method |      Mean |     Error |    StdDev | Code Size |  Gen 0 | Gen 1 | Gen 2 | Allocated | Completed Work Items | Lock Contentions |
+|---------------------------------- |----------:|----------:|----------:|----------:|-------:|------:|------:|----------:|---------------------:|-----------------:|
+|       EqualsSingleProperly_Lambda |  3.268 μs | 0.0635 μs | 0.0780 μs |      6 KB | 0.3319 |     - |     - |      2 KB |                    - |                - |
+| EqualsSingleProperly_AutoFilterer |  4.135 μs | 0.0616 μs | 0.0546 μs |      0 KB | 0.2670 |     - |     - |      2 KB |                    - |                - |
+|               StringFilter_Lambda | 23.582 μs | 0.2512 μs | 0.2350 μs |     20 KB | 2.6245 |     - |     - |     16 KB |                    - |                - |
+|         StringFilter_AutoFilterer |  8.117 μs | 0.1265 μs | 0.1122 μs |      0 KB | 0.6561 |     - |     - |      4 KB |                    - |                - |
+|                  MinAndMax_Lambda |  4.763 μs | 0.0723 μs | 0.0676 μs |     11 KB | 0.4654 |     - |     - |      3 KB |                    - |                - |
+|            MinAndMax_AutoFilterer |  4.245 μs | 0.0349 μs | 0.0310 μs |      0 KB | 0.2823 |     - |     - |      2 KB |                    - |                - |
+|              ComplexFilter_Lambda | 16.613 μs | 0.0699 μs | 0.0620 μs |     17 KB | 1.7090 |     - |     - |     11 KB |                    - |                - |
+|        ComplexFilter_AutoFilterer | 13.625 μs | 0.1886 μs | 0.1764 μs |      0 KB | 0.7019 |     - |     - |      4 KB |                    - |                - |

--- a/src/AutoFilterer.Dynamics/DynamicFilter.cs
+++ b/src/AutoFilterer.Dynamics/DynamicFilter.cs
@@ -21,15 +21,15 @@ public class DynamicFilter : Dictionary<string, string>, IFilter
 
     private static readonly Dictionary<string, IFilterableType> specialKeywords = new Dictionary<string, IFilterableType>
         {
-            { "eq", new OperatorComparisonAttribute(OperatorType.Equal) },
-            { "not", new OperatorComparisonAttribute(OperatorType.NotEqual) },
-            { "gt", new OperatorComparisonAttribute(OperatorType.GreaterThan) },
-            { "gte", new OperatorComparisonAttribute(OperatorType.GreaterThanOrEqual) },
-            { "lt", new OperatorComparisonAttribute(OperatorType.LessThan) },
-            { "lte", new OperatorComparisonAttribute(OperatorType.LessThanOrEqual) },
-            { "contains", new StringFilterOptionsAttribute(StringFilterOption.Contains) },
-            { "endswith", new StringFilterOptionsAttribute(StringFilterOption.EndsWith) },
-            { "startswith", new StringFilterOptionsAttribute(StringFilterOption.StartsWith) },
+            { "eq", OperatorComparisonAttribute.Equal },
+            { "not", OperatorComparisonAttribute.NotEqual },
+            { "gt", OperatorComparisonAttribute.GreaterThan },
+            { "gte", OperatorComparisonAttribute.GreaterThanOrEqual },
+            { "lt", OperatorComparisonAttribute.LessThan },
+            { "lte", OperatorComparisonAttribute.LessThanOrEqual },
+            { "contains", StringFilterOptionsAttribute.Contains },
+            { "endswith", StringFilterOptionsAttribute.EndsWith },
+            { "startswith", StringFilterOptionsAttribute.StartsWith },
         };
 
     public CombineType CombineWith { get; set; }
@@ -71,7 +71,7 @@ public class DynamicFilter : Dictionary<string, string>, IFilter
             {
                 var targetProperty = entityType.GetProperty(key);
                 var value = Convert.ChangeType((string)filterValue, targetProperty.PropertyType);
-                var exp = new OperatorComparisonAttribute(OperatorType.Equal).BuildExpression(body, targetProperty, filterProperty: null, value);
+                var exp = OperatorComparisonAttribute.Equal.BuildExpression(body, targetProperty, filterProperty: null, value);
 
                 var combined = finalExpression.Combine(exp, CombineWith);
                 finalExpression = body.Combine(combined, CombineWith);

--- a/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
+++ b/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AutoFilterer.Attributes;
 

--- a/src/AutoFilterer/Attributes/CompareToAttribute.cs
+++ b/src/AutoFilterer/Attributes/CompareToAttribute.cs
@@ -92,8 +92,7 @@ public class CompareToAttribute : FilteringOptionsBaseAttribute
         {
             if (typeof(ICollection).IsAssignableFrom(targetProperty.PropertyType) || (targetProperty.PropertyType.IsConstructedGenericType && typeof(IEnumerable).IsAssignableFrom(targetProperty.PropertyType)))
             {
-                var collectionAttribute = new CollectionFilterAttribute();
-                return collectionAttribute.BuildExpression(expressionBody, targetProperty, filterProperty, value);
+                return Singleton<CollectionFilterAttribute>.Instance.BuildExpression(expressionBody, targetProperty, filterProperty, value);
             }
             else
             {
@@ -108,11 +107,11 @@ public class CompareToAttribute : FilteringOptionsBaseAttribute
         }
         else if (filterProperty.PropertyType.IsArray && !typeof(ICollection).IsAssignableFrom(targetProperty.PropertyType))
         {
-            return new ArraySearchFilterAttribute().BuildExpression(expressionBody, targetProperty, filterProperty, value);
+            return Singleton<ArraySearchFilterAttribute>.Instance.BuildExpression(expressionBody, targetProperty, filterProperty, value);
         }
         else
         {
-            return new OperatorComparisonAttribute(OperatorType.Equal).BuildExpression(expressionBody, targetProperty, filterProperty, value);
+            return OperatorComparisonAttribute.Equal.BuildExpression(expressionBody, targetProperty, filterProperty, value);
         }
     }
 }

--- a/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
+++ b/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
@@ -44,4 +44,24 @@ public class OperatorComparisonAttribute : FilteringOptionsBaseAttribute
 
         return Expression.Empty();
     }
+
+    #region Static
+
+    public static OperatorComparisonAttribute Equal { get; }
+    public static OperatorComparisonAttribute NotEqual { get; }
+    public static OperatorComparisonAttribute GreaterThan { get; }
+    public static OperatorComparisonAttribute GreaterThanOrEqual { get; }
+    public static OperatorComparisonAttribute LessThan { get; }
+    public static OperatorComparisonAttribute LessThanOrEqual { get; }
+
+    static OperatorComparisonAttribute()
+    {
+        Equal = new OperatorComparisonAttribute(OperatorType.Equal);
+        NotEqual = new OperatorComparisonAttribute(OperatorType.NotEqual);
+        GreaterThan = new OperatorComparisonAttribute(OperatorType.GreaterThan);
+        GreaterThanOrEqual = new OperatorComparisonAttribute(OperatorType.GreaterThanOrEqual);
+        LessThan = new OperatorComparisonAttribute(OperatorType.LessThan);
+        LessThanOrEqual = new OperatorComparisonAttribute(OperatorType.LessThanOrEqual);
+    }
+    #endregion
 }

--- a/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
+++ b/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
@@ -55,4 +55,16 @@ public class StringFilterOptionsAttribute : FilteringOptionsBaseAttribute
 
         return comparison;
     }
+
+    #region Static
+    public static StringFilterOptionsAttribute Contains { get; }
+    public static StringFilterOptionsAttribute EndsWith { get; }
+    public static StringFilterOptionsAttribute StartsWith { get; }
+    static StringFilterOptionsAttribute()
+    {
+        Contains = new StringFilterOptionsAttribute(StringFilterOption.Contains);
+        EndsWith = new StringFilterOptionsAttribute(StringFilterOption.EndsWith);
+        StartsWith = new StringFilterOptionsAttribute(StringFilterOption.StartsWith);
+    }
+    #endregion
 }

--- a/src/AutoFilterer/Singleton.cs
+++ b/src/AutoFilterer/Singleton.cs
@@ -1,0 +1,24 @@
+﻿namespace AutoFilterer
+{
+    internal static class Singleton<T>
+        where T : class, new()
+    {
+        private static T _instance;
+        private static object lockingObj = new object();
+        internal static T Instance
+        {
+            get
+            {
+                lock (lockingObj)
+                {
+                    if (_instance is null)
+                    {
+                        _instance = new T();
+                    }
+                }
+
+                return _instance;
+            }
+        }
+    }
+}

--- a/src/AutoFilterer/Types/OperatorFilter.cs
+++ b/src/AutoFilterer/Types/OperatorFilter.cs
@@ -25,22 +25,22 @@ public class OperatorFilter<T> : IFilterableType
         Expression expression = null;
 
         if (Eq != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.Equal).BuildExpression(expressionBody, targetProperty, filterProperty, Eq), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.Equal.BuildExpression(expressionBody, targetProperty, filterProperty, Eq), CombineWith);
 
         if (Gt != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.GreaterThan).BuildExpression(expressionBody, targetProperty, filterProperty, Gt), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.GreaterThan.BuildExpression(expressionBody, targetProperty, filterProperty, Gt), CombineWith);
 
         if (Lt != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.LessThan).BuildExpression(expressionBody, targetProperty, filterProperty, Lt), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.LessThan.BuildExpression(expressionBody, targetProperty, filterProperty, Lt), CombineWith);
 
         if (Gte != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.GreaterThanOrEqual).BuildExpression(expressionBody, targetProperty, filterProperty, Gte), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.GreaterThanOrEqual.BuildExpression(expressionBody, targetProperty, filterProperty, Gte), CombineWith);
 
         if (Lte != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.LessThanOrEqual).BuildExpression(expressionBody, targetProperty, filterProperty, Lte), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.LessThanOrEqual.BuildExpression(expressionBody, targetProperty, filterProperty, Lte), CombineWith);
 
         if (Not != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.NotEqual).BuildExpression(expressionBody, targetProperty, filterProperty, Not), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.NotEqual.BuildExpression(expressionBody, targetProperty, filterProperty, Not), CombineWith);
 
         return expression;
     }

--- a/src/AutoFilterer/Types/StringFilter.cs
+++ b/src/AutoFilterer/Types/StringFilter.cs
@@ -57,10 +57,10 @@ public class StringFilter : IFilterableType
         Expression expression = null;
 
         if (Eq != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.Equal).BuildExpression(expressionBody, targetProperty, filterProperty, Eq), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.Equal.BuildExpression(expressionBody, targetProperty, filterProperty, Eq), CombineWith);
 
         if (Not != null)
-            expression = expression.Combine(new OperatorComparisonAttribute(OperatorType.NotEqual).BuildExpression(expressionBody, targetProperty, filterProperty, Not), CombineWith);
+            expression = expression.Combine(OperatorComparisonAttribute.NotEqual.BuildExpression(expressionBody, targetProperty, filterProperty, Not), CombineWith);
 
         if (Equals != null)
             expression = expression.Combine(new StringFilterOptionsAttribute(StringFilterOption.Equals) { Comparison = Compare }.BuildExpression(expressionBody, targetProperty, filterProperty, Equals), CombineWith);


### PR DESCRIPTION
Instead of creating a new instance each time.

Performance is highly improved with this PR. It's almost doubled.

Query generation times are reduced to half of earlier version

## Old Result
<html>
<body>
<!--StartFragment-->

Method | Mean | Error | StdDev | Completed Work Items | Gen 0 | Gen 1 | Gen 2 | Allocated | Code Size
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
EqualsSingleProperly_Lambda | 3.184 μs | 0.0153 μs | 0.0144 μs | 0.0000 | 0.2861 | - | - | 2 KB | 3 KB
EqualsSingleProperly_AutoFilterer | 8.348 μs | 0.0576 μs | 0.0539 μs | 0.0000 | 0.6409 | - | - | 4 KB | 0 KB
StringFilter_Lambda | 26.384 μs | 0.1595 μs | 0.1414 μs | 0.0001 | 2.4414 | 0.0305 | - | 15 KB | 23 KB
StringFilter_AutoFilterer | 14.163 μs | 0.1540 μs | 0.1440 μs | 0.0000 | 1.0681 | - | - | 7 KB | 0 KB
MinAndMax_Lambda | 5.176 μs | 0.0661 μs | 0.0586 μs | 0.0000 | 0.4501 | - | - | 3 KB | 7 KB
MinAndMax_AutoFilterer | 8.756 μs | 0.0653 μs | 0.0579 μs | 0.0000 | 0.6561 | - | - | 4 KB | 0 KB
ComplexFilter_Lambda | 18.311 μs | 0.1326 μs | 0.1175 μs | 0.0001 | 1.5259 | - | - | 9 KB | 14 KB
ComplexFilter_AutoFilterer | 25.776 μs | 0.1496 μs | 0.1399 μs | 0.0001 | 2.1057 | - | - | 13 KB | 0 KB
<!--EndFragment-->
</body>
</html>

 ## New Result

<html>
<body>
<!--StartFragment-->

Method | Mean | Error | StdDev | Code Size | Gen 0 | Gen 1 | Gen 2 | Allocated | Completed Work Items | Lock Contentions
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
EqualsSingleProperly_Lambda | 3.268 μs | 0.0635 μs | 0.0780 μs | 6 KB | 0.3319 | - | - | 2 KB | - | -
EqualsSingleProperly_AutoFilterer | 4.135 μs | 0.0616 μs | 0.0546 μs | 0 KB | 0.2670 | - | - | 2 KB | - | -
StringFilter_Lambda | 23.582 μs | 0.2512 μs | 0.2350 μs | 20 KB | 2.6245 | - | - | 16 KB | - | -
StringFilter_AutoFilterer | 8.117 μs | 0.1265 μs | 0.1122 μs | 0 KB | 0.6561 | - | - | 4 KB | - | -
MinAndMax_Lambda | 4.763 μs | 0.0723 μs | 0.0676 μs | 11 KB | 0.4654 | - | - | 3 KB | - | -
MinAndMax_AutoFilterer | 4.245 μs | 0.0349 μs | 0.0310 μs | 0 KB | 0.2823 | - | - | 2 KB | - | -
ComplexFilter_Lambda | 16.613 μs | 0.0699 μs | 0.0620 μs | 17 KB | 1.7090 | - | - | 11 KB | - | -
ComplexFilter_AutoFilterer | 13.625 μs | 0.1886 μs | 0.1764 μs | 0 KB | 0.7019 | - | - | 4 KB | - | -

<!--EndFragment-->
</body>
</html>

