### PR TITLE
Convert to property access instead constants

### DIFF
--- a/src/AutoFilterer.Dynamics/DynamicFilter.cs
+++ b/src/AutoFilterer.Dynamics/DynamicFilter.cs
@@ -66,12 +66,15 @@ public class DynamicFilter : Dictionary<string, string>, IFilter
 
         foreach (var key in this.Keys)
         {
+            var filterPropertyExpression = Expression.Property(Expression.Constant(this), key);
             var filterValue = new DynamicFilter(this[key]);
             if (IsPrimitive(key))
             {
                 var targetProperty = entityType.GetProperty(key);
                 var value = Convert.ChangeType((string)filterValue, targetProperty.PropertyType);
-                var exp = OperatorComparisonAttribute.Equal.BuildExpression(body, targetProperty, filterProperty: null, value);
+                //var exp = OperatorComparisonAttribute.Equal.BuildExpression(body, targetProperty, filterProperty: null, value);
+
+                var exp = OperatorComparisonAttribute.Equal.BuildExpression(new ExpressionBuildContext(body, targetProperty, null, filterPropertyExpression, this, value));
 
                 var combined = finalExpression.Combine(exp, CombineWith);
                 finalExpression = body.Combine(combined, CombineWith);
@@ -87,7 +90,7 @@ public class DynamicFilter : Dictionary<string, string>, IFilter
                     var comparisonKeyword = splitted[1];
                     if (specialKeywords.TryGetValue(comparisonKeyword, out IFilterableType filterable))
                     {
-                        var exp = filterable.BuildExpression(body, targetProperty, filterProperty: null, value);
+                        var exp = filterable.BuildExpression(new ExpressionBuildContext(body, targetProperty, null, filterPropertyExpression, this, value));
 
                         var combined = finalExpression.Combine(exp, CombineWith);
                         finalExpression = body.Combine(combined, CombineWith);

--- a/src/AutoFilterer.Dynamics/DynamicFilter.cs
+++ b/src/AutoFilterer.Dynamics/DynamicFilter.cs
@@ -66,15 +66,17 @@ public class DynamicFilter : Dictionary<string, string>, IFilter
 
         foreach (var key in this.Keys)
         {
-            var filterPropertyExpression = Expression.Property(Expression.Constant(this), key);
-            var filterValue = new DynamicFilter(this[key]);
+            var getter = this.GetType().GetMethod("get_Item");
+            var filterPropertyExpression = Expression.Call(Expression.Constant(this), getter, Expression.Constant(key));
+            var filterValue = getter.Invoke(this, parameters: [key]);
             if (IsPrimitive(key))
             {
                 var targetProperty = entityType.GetProperty(key);
                 var value = Convert.ChangeType((string)filterValue, targetProperty.PropertyType);
                 //var exp = OperatorComparisonAttribute.Equal.BuildExpression(body, targetProperty, filterProperty: null, value);
 
-                var exp = OperatorComparisonAttribute.Equal.BuildExpression(new ExpressionBuildContext(body, targetProperty, null, filterPropertyExpression, this, value));
+                var exp = OperatorComparisonAttribute.Equal.BuildExpression(
+                    new ExpressionBuildContext(body, targetProperty, null, filterPropertyExpression, this, value));
 
                 var combined = finalExpression.Combine(exp, CombineWith);
                 finalExpression = body.Combine(combined, CombineWith);

--- a/src/AutoFilterer.Dynamics/DynamicFilter.cs
+++ b/src/AutoFilterer.Dynamics/DynamicFilter.cs
@@ -68,7 +68,7 @@ public class DynamicFilter : Dictionary<string, string>, IFilter
         {
             var getter = this.GetType().GetMethod("get_Item");
             var filterPropertyExpression = Expression.Call(Expression.Constant(this), getter, Expression.Constant(key));
-            var filterValue = getter.Invoke(this, parameters: [key]);
+            var filterValue = getter.Invoke(this, parameters: new object[] { key });
             if (IsPrimitive(key))
             {
                 var targetProperty = entityType.GetProperty(key);

--- a/src/AutoFilterer/Abstractions/IFilterableType.cs
+++ b/src/AutoFilterer/Abstractions/IFilterableType.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 namespace AutoFilterer.Abstractions;
 
 /// <summary>
-/// Any property type which is able to <see cref="BuildExpression(Expression, PropertyInfo, PropertyInfo, object)"/> over source property.
+/// Any property type which is able to <see cref="BuildExpression(Expression, PropertyInfo, PropertyInfo, MemberExpression)"/> over source property.
 /// <list type="table">
 /// <item>
 /// You can create new Complex Types via implementing this interface. It'll be automatically called if defined in an object which is implements <see cref="IFilter"/>.
@@ -14,5 +14,5 @@ namespace AutoFilterer.Abstractions;
 /// </summary>
 public interface IFilterableType
 {
-    Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value);
+    Expression BuildExpression(ExpressionBuildContext context);
 }

--- a/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
+++ b/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
@@ -27,10 +27,6 @@ public class ArraySearchFilterAttribute : FilteringOptionsBaseAttribute
                                                         Expression.Property(context.ExpressionBody, context.TargetProperty)
                                                 });
 
-        
-
-        // x => filter.Status.Contains(x.Status)
-
         return containsExpression;
     }
 }

--- a/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
+++ b/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
@@ -7,12 +7,15 @@ namespace AutoFilterer.Attributes;
 
 public class ArraySearchFilterAttribute : FilteringOptionsBaseAttribute
 {
-    public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+    public override Expression BuildExpression(ExpressionBuildContext context)
     {
-        if (value is ICollection list && list.Count == 0)
-            return Expression.Constant(true);
-        var type = targetProperty.PropertyType;
-        var prop = Expression.Property(expressionBody, targetProperty.Name);
+        if (context.FilterProperty is ICollection list && list.Count == 0)
+        {
+            return Expression.Constant(true); // TODO: Make it better. Maybe return null? When null, it should be ignored and combined with another expressions.
+        }
+
+        var type = context.TargetProperty.PropertyType;
+        var prop = Expression.Property(context.ExpressionBody, context.TargetProperty.Name);
 
         var containsMethod = typeof(Enumerable).GetMethods().FirstOrDefault(x => x.Name == nameof(Enumerable.Contains)).MakeGenericMethod(type);
 
@@ -20,9 +23,13 @@ public class ArraySearchFilterAttribute : FilteringOptionsBaseAttribute
                                                 method: containsMethod,
                                                 arguments: new Expression[]
                                                 {
-                                                        Expression.Constant(value),
-                                                        Expression.Property(expressionBody, targetProperty.Name)
+                                                        Expression.Property(Expression.Constant(context.FilterObject), context.FilterProperty),
+                                                        Expression.Property(context.ExpressionBody, context.TargetProperty)
                                                 });
+
+        
+
+        // x => filter.Status.Contains(x.Status)
 
         return containsExpression;
     }

--- a/src/AutoFilterer/Attributes/CompareToAttribute.cs
+++ b/src/AutoFilterer/Attributes/CompareToAttribute.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System;
-using AutoFilterer.Types;
 
 namespace AutoFilterer.Attributes;
 
@@ -99,7 +98,6 @@ public class CompareToAttribute : FilteringOptionsBaseAttribute
         return BuildDefaultExpression(context);
     }
 
-    //public virtual Expression BuildDefaultExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, MemberExpression filterPropertyExpression)
     public virtual Expression BuildDefaultExpression(ExpressionBuildContext context)
     {
         if (context.FilterObjectPropertyValue is IFilter filter)
@@ -115,8 +113,6 @@ public class CompareToAttribute : FilteringOptionsBaseAttribute
                 return filter.BuildExpression(context.TargetProperty.PropertyType, parameter);
             }
         }
-
-
 
         if (context.FilterObjectPropertyValue is IFilterableType filterableProperty)
         {

--- a/src/AutoFilterer/Attributes/FilteringOptionsBaseAttribute.cs
+++ b/src/AutoFilterer/Attributes/FilteringOptionsBaseAttribute.cs
@@ -8,5 +8,5 @@ namespace AutoFilterer.Attributes;
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public abstract class FilteringOptionsBaseAttribute : Attribute, IFilterableType
 {
-    public abstract Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value);
+    public abstract Expression BuildExpression(ExpressionBuildContext context);
 }

--- a/src/AutoFilterer/Attributes/FilteringOptionsBaseAttribute.cs
+++ b/src/AutoFilterer/Attributes/FilteringOptionsBaseAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using AutoFilterer.Abstractions;
+using AutoFilterer.Extensions;
 using System;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace AutoFilterer.Attributes;
 
@@ -9,4 +9,21 @@ namespace AutoFilterer.Attributes;
 public abstract class FilteringOptionsBaseAttribute : Attribute, IFilterableType
 {
     public abstract Expression BuildExpression(ExpressionBuildContext context);
+
+    protected Expression BuildFilterExpression(ExpressionBuildContext context)
+    {
+        var filterProp = context.FilterPropertyExpression;
+
+        if (context.FilterProperty is null)
+        {
+            return Expression.Constant(context.FilterObjectPropertyValue);
+        }
+
+        if (context.FilterProperty.PropertyType.IsNullable())
+        {
+            filterProp = Expression.Property(filterProp, nameof(Nullable<bool>.Value));
+        }
+
+        return filterProp;
+    }
 }

--- a/src/AutoFilterer/Attributes/IgnoreFilterAttribute.cs
+++ b/src/AutoFilterer/Attributes/IgnoreFilterAttribute.cs
@@ -7,8 +7,8 @@ namespace AutoFilterer.Attributes;
 [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
 public class IgnoreFilterAttribute : FilteringOptionsBaseAttribute
 {
-    public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+    public override Expression BuildExpression(ExpressionBuildContext context)
     {
-        return expressionBody;
+        return context.ExpressionBody;
     }
 }

--- a/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
+++ b/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
@@ -18,34 +18,35 @@ public class OperatorComparisonAttribute : FilteringOptionsBaseAttribute
 
     public OperatorType OperatorType { get; }
 
-    public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty,
-        PropertyInfo filterProperty, object value)
+    public override Expression BuildExpression(ExpressionBuildContext context)
     {
-        var prop = Expression.Property(expressionBody, targetProperty.Name);
-        var param = Expression.Constant(value);
-        var targetIsNullable = targetProperty.PropertyType.IsNullable() || targetProperty.PropertyType == typeof(string);
+        var prop = Expression.Property(context.ExpressionBody, context.TargetProperty.Name);
 
-        if (targetProperty.PropertyType.IsNullable())
+        var filterProp = Expression.Property(Expression.Constant(context.FilterObject), context.FilterProperty);
+
+        var targetIsNullable = context.TargetProperty.PropertyType.IsNullable() || context.TargetProperty.PropertyType == typeof(string);
+
+        if (context.TargetProperty.PropertyType.IsNullable())
             prop = Expression.Property(prop, nameof(Nullable<bool>.Value));
         
         switch (OperatorType)
         {
             case OperatorType.Equal:
-                return Expression.Equal(prop, param);
+                return Expression.Equal(prop, filterProp);
             case OperatorType.NotEqual:
-                return Expression.NotEqual(prop, param);
+                return Expression.NotEqual(prop, filterProp);
             case OperatorType.GreaterThan:
-                return Expression.GreaterThan(prop, param);
+                return Expression.GreaterThan(prop, filterProp);
             case OperatorType.GreaterThanOrEqual:
-                return Expression.GreaterThanOrEqual(prop, param);
+                return Expression.GreaterThanOrEqual(prop, filterProp);
             case OperatorType.LessThan:
-                return Expression.LessThan(prop, param);
+                return Expression.LessThan(prop, filterProp);
             case OperatorType.LessThanOrEqual:
-                return Expression.LessThanOrEqual(prop, param);
+                return Expression.LessThanOrEqual(prop, filterProp);
             case OperatorType.IsNull:
-                return targetIsNullable ? Expression.Equal(Expression.Property(expressionBody, targetProperty.Name), Expression.Constant(null)) : null;
+                return targetIsNullable ? Expression.Equal(Expression.Property(context.ExpressionBody, context.TargetProperty.Name), Expression.Constant(null)) : null;
             case OperatorType.IsNotNull:
-                return targetIsNullable ? Expression.Not(Expression.Equal(Expression.Property(expressionBody, targetProperty.Name), Expression.Constant(null))) : null;
+                return targetIsNullable ? Expression.Not(Expression.Equal(Expression.Property(context.ExpressionBody, context.TargetProperty.Name), Expression.Constant(null))) : null;
         }
 
         return Expression.Empty();

--- a/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
+++ b/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
@@ -22,13 +22,20 @@ public class OperatorComparisonAttribute : FilteringOptionsBaseAttribute
     {
         var prop = Expression.Property(context.ExpressionBody, context.TargetProperty.Name);
 
-        var filterProp = Expression.Property(Expression.Constant(context.FilterObject), context.FilterProperty);
+        var filterProp = context.FilterPropertyExpression;
+
+        if (context.FilterProperty.PropertyType.IsNullable())
+        {
+            filterProp = Expression.Property(filterProp, nameof(Nullable<bool>.Value));
+        }
 
         var targetIsNullable = context.TargetProperty.PropertyType.IsNullable() || context.TargetProperty.PropertyType == typeof(string);
 
         if (context.TargetProperty.PropertyType.IsNullable())
+        {
             prop = Expression.Property(prop, nameof(Nullable<bool>.Value));
-        
+        }
+
         switch (OperatorType)
         {
             case OperatorType.Equal:

--- a/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
+++ b/src/AutoFilterer/Attributes/OperatorComparisonAttribute.cs
@@ -22,12 +22,7 @@ public class OperatorComparisonAttribute : FilteringOptionsBaseAttribute
     {
         var prop = Expression.Property(context.ExpressionBody, context.TargetProperty.Name);
 
-        var filterProp = context.FilterPropertyExpression;
-
-        if (context.FilterProperty.PropertyType.IsNullable())
-        {
-            filterProp = Expression.Property(filterProp, nameof(Nullable<bool>.Value));
-        }
+        var filterProp = BuildFilterExpression(context);
 
         var targetIsNullable = context.TargetProperty.PropertyType.IsNullable() || context.TargetProperty.PropertyType == typeof(string);
 

--- a/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
+++ b/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
@@ -38,12 +38,13 @@ public class StringFilterOptionsAttribute : FilteringOptionsBaseAttribute
 
     private Expression BuildExpressionWithComparison(StringFilterOption option, ExpressionBuildContext context)
     {
-        var method = typeof(string).GetMethod(option.ToString(), types: new[] { typeof(string), typeof(StringComparison) });        
+        var method = typeof(string).GetMethod(option.ToString(), types: new[] { typeof(string), typeof(StringComparison) });
+        var filterProp = BuildFilterExpression(context);
 
         var comparison = Expression.Call(
                               method: method,
                               instance: Expression.Property(context.ExpressionBody, context.TargetProperty.Name),
-                              arguments: new Expression[] { context.FilterPropertyExpression, Expression.Constant(Comparison) });
+                              arguments: new Expression[] { filterProp, Expression.Constant(Comparison) });
 
         return comparison;
     }
@@ -52,10 +53,12 @@ public class StringFilterOptionsAttribute : FilteringOptionsBaseAttribute
     {
         var method = typeof(string).GetMethod(option.ToString(), types: new[] { typeof(string) });
 
+        var filterProp = BuildFilterExpression(context);
+
         var comparison = Expression.Call(
                             method: method,
                             instance: Expression.Property(context.ExpressionBody, context.TargetProperty.Name),
-                            arguments: new[] { context.FilterPropertyExpression });
+                            arguments: new[] { filterProp });
 
         return comparison;
     }

--- a/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
+++ b/src/AutoFilterer/Attributes/StringFilterOptionsAttribute.cs
@@ -24,34 +24,38 @@ public class StringFilterOptionsAttribute : FilteringOptionsBaseAttribute
 
     public StringComparison? Comparison { get; set; }
 
-    public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+    public override Expression BuildExpression(ExpressionBuildContext context)
     {
         if (Comparison == null)
-            return BuildExpressionWithoutComparison(this.Option, expressionBody, targetProperty, value);
+        {
+            return BuildExpressionWithoutComparison(this.Option, context);
+        }
         else
-            return BuildExpressionWithComparison(this.Option, expressionBody, targetProperty, value);
+        {
+            return BuildExpressionWithComparison(this.Option, context);
+        }
     }
 
-    private Expression BuildExpressionWithComparison(StringFilterOption option, Expression expressionBody, PropertyInfo property, object value)
+    private Expression BuildExpressionWithComparison(StringFilterOption option, ExpressionBuildContext context)
     {
-        var method = typeof(string).GetMethod(option.ToString(), types: new[] { typeof(string), typeof(StringComparison) });
+        var method = typeof(string).GetMethod(option.ToString(), types: new[] { typeof(string), typeof(StringComparison) });        
 
         var comparison = Expression.Call(
                               method: method,
-                              instance: Expression.Property(expressionBody, property.Name),
-                              arguments: new[] { Expression.Constant(value), Expression.Constant(Comparison) });
+                              instance: Expression.Property(context.ExpressionBody, context.TargetProperty.Name),
+                              arguments: new Expression[] { context.FilterPropertyExpression, Expression.Constant(Comparison) });
 
         return comparison;
     }
 
-    private Expression BuildExpressionWithoutComparison(StringFilterOption option, Expression expressionBody, PropertyInfo property, object value)
+    private Expression BuildExpressionWithoutComparison(StringFilterOption option, ExpressionBuildContext context)
     {
         var method = typeof(string).GetMethod(option.ToString(), types: new[] { typeof(string) });
 
         var comparison = Expression.Call(
                             method: method,
-                            instance: Expression.Property(expressionBody, property.Name),
-                            arguments: new[] { Expression.Constant(value) });
+                            instance: Expression.Property(context.ExpressionBody, context.TargetProperty.Name),
+                            arguments: new[] { context.FilterPropertyExpression });
 
         return comparison;
     }

--- a/src/AutoFilterer/Attributes/ToLowerContainsComparisonAttribute.cs
+++ b/src/AutoFilterer/Attributes/ToLowerContainsComparisonAttribute.cs
@@ -11,7 +11,7 @@ namespace AutoFilterer.Attributes;
 /// </summary>
 public class ToLowerContainsComparisonAttribute : FilteringOptionsBaseAttribute
 {
-    public override Expression BuildExpression(Expression expressionBody, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+    public override Expression BuildExpression(ExpressionBuildContext context)
     {
         var containsMethod = typeof(string).GetMethod(nameof(string.Contains), types: new[] { typeof(string) });
 
@@ -20,9 +20,9 @@ public class ToLowerContainsComparisonAttribute : FilteringOptionsBaseAttribute
         var comparison = Expression.Equal(
                     Expression.Call(
                         method: containsMethod,
-                        instance: Expression.Call(method: toLowerMethod, instance: Expression.Property(expressionBody, targetProperty.Name)
+                        instance: Expression.Call(method: toLowerMethod, instance: Expression.Property(context.ExpressionBody, context.TargetProperty.Name)
                             ),
-                        arguments: new[] { Expression.Call(method: toLowerMethod, instance: Expression.Constant(value)) }),
+                        arguments: new[] { Expression.Call(method: toLowerMethod, instance: context.FilterPropertyExpression) }),
                     Expression.Constant(true));
 
         return comparison;

--- a/src/AutoFilterer/ExpressionBuildContext.cs
+++ b/src/AutoFilterer/ExpressionBuildContext.cs
@@ -1,0 +1,38 @@
+﻿using AutoFilterer.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace AutoFilterer;
+public class ExpressionBuildContext
+{
+    public ExpressionBuildContext(
+        Expression expressionBody,
+        PropertyInfo targetProperty,
+        PropertyInfo filterProperty,
+        Expression filterPropertyExpression,
+        IFilter filterObject,
+        object propertyValue)
+    {
+        ExpressionBody = expressionBody;
+        TargetProperty = targetProperty;
+        FilterProperty = filterProperty;
+        FilterPropertyExpression = filterPropertyExpression;
+        FilterObject = filterObject;
+        FilterObjectPropertyValue = propertyValue;
+    }
+
+    public Expression ExpressionBody { get; }
+
+    public PropertyInfo TargetProperty { get; }
+
+    public PropertyInfo FilterProperty { get; }
+
+    public Expression FilterPropertyExpression { get; }
+
+    public IFilter FilterObject { get; }
+
+    public object FilterObjectPropertyValue { get; }
+}

--- a/src/AutoFilterer/Extensions/NullableExtensions.cs
+++ b/src/AutoFilterer/Extensions/NullableExtensions.cs
@@ -11,6 +11,11 @@ public static class NullableExtensions
 {
     public static bool IsNullable(this Type type)
     {
+        if (type is null)
+        {
+            return false;
+        }
+
         return type.Name == typeof(Nullable<>).Name;
     }
 

--- a/src/AutoFilterer/Types/FilterBase.cs
+++ b/src/AutoFilterer/Types/FilterBase.cs
@@ -45,9 +45,13 @@ public class FilterBase : IFilter
         {
             try
             {
-                var val = filterProperty.GetValue(this);
-                if (val == null || filterProperty.GetCustomAttribute<IgnoreFilterAttribute>() != null)
+                var filterPropertyValue = filterProperty.GetValue(this);
+                var filterPropertyExpression = Expression.Property(Expression.Constant(this), filterProperty);
+
+                if (filterPropertyValue == null || filterProperty.GetCustomAttribute<IgnoreFilterAttribute>() != null)
+                {
                     continue;
+                }
 
                 var attributes = filterProperty.GetCustomAttributes<CompareToAttribute>(inherit: true);
 
@@ -68,7 +72,9 @@ public class FilterBase : IFilter
 
                         var bodyParameter = finalExpression is MemberExpression ? finalExpression : body;
 
-                        var expression = attribute.BuildExpressionForProperty(bodyParameter, targetProperty, filterProperty, val);
+                        var expression = attribute.BuildExpressionForProperty(
+                            new ExpressionBuildContext(bodyParameter, targetProperty, filterProperty, filterPropertyExpression, this, filterPropertyValue));
+
                         innerExpression = innerExpression.Combine(expression, attribute.CombineWith);
                     }
                 }

--- a/src/AutoFilterer/Types/OperatorFilter.cs
+++ b/src/AutoFilterer/Types/OperatorFilter.cs
@@ -27,7 +27,13 @@ public class OperatorFilter<T> : IFilterableType
         Expression expression = null;
 
         if (Eq != null)
-            expression = expression.Combine(OperatorComparisonAttribute.Equal.BuildExpression(ContextFor(context, nameof(Eq), Eq)), CombineWith);
+        {
+            expression = expression.Combine(
+                OperatorComparisonAttribute.Equal.BuildExpression(
+                    ContextFor(context, nameof(Eq), Eq)
+                ),
+                CombineWith);
+        }
 
         if (Gt != null)
             expression = expression.Combine(OperatorComparisonAttribute.GreaterThan.BuildExpression(ContextFor(context, nameof(Gt), Gt)), CombineWith);

--- a/src/AutoFilterer/Types/Range.cs
+++ b/src/AutoFilterer/Types/Range.cs
@@ -57,7 +57,7 @@ public class Range<T> : IRange<T>, IRange, IEquatable<string>, IFormattable
         return $"{this.Min?.ToString() ?? "-"}|{this.Max?.ToString() ?? "-"}";
     }
 
-    public virtual Expression BuildExpression(Expression body, PropertyInfo targetProperty, PropertyInfo filterProperty, object value)
+    public virtual Expression BuildExpression(ExpressionBuildContext context)
     {
         return GetRangeComparison();
 
@@ -65,9 +65,11 @@ public class Range<T> : IRange<T>, IRange, IEquatable<string>, IFormattable
         {
             BinaryExpression minExp = default, maxExp = default;
 
-            var propertyExpression = Expression.Property(body, targetProperty.Name);
-            if (targetProperty.PropertyType.IsNullable())
+            var propertyExpression = Expression.Property(context.ExpressionBody, context.TargetProperty.Name);
+            if (context.TargetProperty.PropertyType.IsNullable())
+            {
                 propertyExpression = Expression.Property(propertyExpression, nameof(Nullable<bool>.Value));
+            }
 
             if (Min != null)
             {
@@ -75,7 +77,9 @@ public class Range<T> : IRange<T>, IRange, IEquatable<string>, IFormattable
                            propertyExpression,
                            Expression.Constant(Min));
                 if (Max == null)
+                {
                     return minExp;
+                }
             }
 
             if (Max != null)
@@ -84,7 +88,9 @@ public class Range<T> : IRange<T>, IRange, IEquatable<string>, IFormattable
                             propertyExpression,
                             Expression.Constant(Max));
                 if (Min == null)
+                {
                     return maxExp;
+                }
             }
 
             return Expression.And(minExp, maxExp);

--- a/tests/AutoFilterer.Tests/Types/FilterBaseTests.cs
+++ b/tests/AutoFilterer.Tests/Types/FilterBaseTests.cs
@@ -169,10 +169,9 @@ public class FilterBaseTests : IDisposable
         filterBase.CombineWith = CombineType.Or;
         var orResult = query.ApplyFilter(filterBase).ToList();
 
-
         // Assert
-        Assert.True(result.Count == dummyData.Count(x => x.Email == filterBase.Email && x.IsActive == filterBase.IsActive));
-        Assert.True(orResult.Count == dummyData.Count(x => x.Email == filterBase.Email || x.IsActive == filterBase.IsActive));
+        Assert.Equal(result.Count, dummyData.Count(x => x.Email == filterBase.Email && x.IsActive == filterBase.IsActive));
+        Assert.Equal(orResult.Count, dummyData.Count(x => x.Email == filterBase.Email || x.IsActive == filterBase.IsActive));
     }
 
     [Theory, AutoMoqData]

--- a/tests/AutoFilterer.Tests/Types/FilterBaseTests.cs
+++ b/tests/AutoFilterer.Tests/Types/FilterBaseTests.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using AutoFilterer.Attributes;
 
 namespace AutoFilterer.Tests.Types;
 
@@ -286,5 +287,28 @@ public class FilterBaseTests : IDisposable
 
         // Assert
         Assert.Equal(expectedQuery.Count(), actualQuery.Count());
+    }
+
+    [Theory, AutoMoqData]
+    public void ApplyFilterTo_ShouldUsePropertyExpression(List<Preferences> dummyData)
+    {
+        // Arrange
+        var filter = new GivenNameFilterObject
+        {
+            GivenName = dummyData.First().GivenName
+        };
+
+        var query = dummyData.AsQueryable();
+
+        // Act
+        var actualQuery = query.ApplyFilter(filter);
+
+        // Assert
+        Assert.DoesNotContain("\"", actualQuery.Expression.ToString());
+    }
+
+    public class GivenNameFilterObject : FilterBase
+    {
+        public string GivenName { get; set; }
     }
 }

--- a/tests/AutoFilterer.Tests/Types/OperatorQueryTests.cs
+++ b/tests/AutoFilterer.Tests/Types/OperatorQueryTests.cs
@@ -11,11 +11,17 @@ using AutoFilterer.Types;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using System;
 
 namespace AutoFilterer.Tests.Types
 {
     public class OperatorQueryTests
     {
+        public OperatorQueryTests()
+        {
+            AutoFiltererConsts.IgnoreExceptions = false;
+        }
+
         [Theory, AutoMoqData(count: 64)]
         public void BuildExpression_TotalPageWithAnd_SholdMatchCount(List<Book> data, BookFilter_OperatorFilter_TotalPage filter)
         {
@@ -77,6 +83,7 @@ namespace AutoFilterer.Tests.Types
         public void BuildExpression_TotalPageEqWithAnd_ShouldMatchCount(List<Book> data, int totalPage)
         {
             // Arrange
+
             var filter = new BookFilter_OperatorFilter_TotalPage
             {
                 TotalPage = new OperatorFilter<int>


### PR DESCRIPTION
Resolves #68 

---

## Changes
- All the `Expression.Constant()` usages are converted to `Expression.Property()` _(when possible)_
### Braking Changes
- `BuildExpression()` methods have single parameter and it's `ExpressionBuildContext` from now.