### PR TITLE
Improve array search filter for nullable Guid properties

### DIFF
--- a/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
+++ b/src/AutoFilterer/Attributes/ArraySearchFilterAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using AutoFilterer.Extensions;
+using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -14,8 +15,8 @@ public class ArraySearchFilterAttribute : FilteringOptionsBaseAttribute
             return Expression.Constant(true); // TODO: Make it better. Maybe return null? When null, it should be ignored and combined with another expressions.
         }
 
-        var type = context.TargetProperty.PropertyType;
-        var prop = Expression.Property(context.ExpressionBody, context.TargetProperty.Name);
+        var type = context.TargetProperty.PropertyType.AsNonNullable();
+        var prop = Expression.Property(context.ExpressionBody, context.TargetProperty.Name).GetValueExpressionIfNullable();
 
         var containsMethod = typeof(Enumerable).GetMethods().FirstOrDefault(x => x.Name == nameof(Enumerable.Contains)).MakeGenericMethod(type);
 
@@ -23,8 +24,8 @@ public class ArraySearchFilterAttribute : FilteringOptionsBaseAttribute
                                                 method: containsMethod,
                                                 arguments: new Expression[]
                                                 {
-                                                        Expression.Property(Expression.Constant(context.FilterObject), context.FilterProperty),
-                                                        Expression.Property(context.ExpressionBody, context.TargetProperty)
+                                                        Expression.Property(Expression.Constant(context.FilterObject), context.FilterProperty).GetValueExpressionIfNullable(),
+                                                        Expression.Property(context.ExpressionBody, context.TargetProperty).GetValueExpressionIfNullable()
                                                 });
 
         return containsExpression;

--- a/tests/AutoFilterer.Tests/Attributes/ArraySearchAttributeTests.cs
+++ b/tests/AutoFilterer.Tests/Attributes/ArraySearchAttributeTests.cs
@@ -3,6 +3,7 @@ using AutoFilterer.Tests.Core;
 using AutoFilterer.Tests.Environment.Dtos;
 using AutoFilterer.Tests.Environment.Models;
 using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -48,6 +49,27 @@ public class ArraySearchAttributeTests
 
         // Act
         var expectedResult = queryable.Where(x => filter.SecurityLevel.Contains(x.SecurityLevel));
+        var actualResult = queryable.ApplyFilter(filter);
+
+        // Assert
+        Assert.Equal(expectedResult.Count(), actualResult.Count());
+
+        foreach (var expected in expectedResult)
+            Assert.True(actualResult.Contains(expected));
+    }
+
+    [Theory, AutoMoqData(count: 64)]
+    public void BuildExpression_ShouldGenerateQueryCorrect_Guid_WithoutAttribute(List<Preferences> data)
+    {
+        // Arrange
+        var queryable = data.AsQueryable();
+        var filter = new PreferencesFilter_ArraySearchWithoutAttribute_Guid
+        {
+            OrganizationUnitId = data.Take(3).Select(x => x.OrganizationUnitId.GetValueOrDefault()).ToArray()
+        };
+
+        // Act
+        var expectedResult = queryable.Where(x => filter.OrganizationUnitId.Contains(x.OrganizationUnitId.GetValueOrDefault()));
         var actualResult = queryable.ApplyFilter(filter);
 
         // Assert

--- a/tests/AutoFilterer.Tests/Attributes/ArraySearchAttributeTests.cs
+++ b/tests/AutoFilterer.Tests/Attributes/ArraySearchAttributeTests.cs
@@ -3,7 +3,6 @@ using AutoFilterer.Tests.Core;
 using AutoFilterer.Tests.Environment.Dtos;
 using AutoFilterer.Tests.Environment.Models;
 using System;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/tests/AutoFilterer.Tests/Environment/Dtos/PreferencesFilter_ArraySearchWithoutAttribute_Guid.cs
+++ b/tests/AutoFilterer.Tests/Environment/Dtos/PreferencesFilter_ArraySearchWithoutAttribute_Guid.cs
@@ -1,0 +1,10 @@
+using AutoFilterer.Attributes;
+using AutoFilterer.Types;
+using System;
+
+namespace AutoFilterer.Tests.Environment.Dtos;
+
+public class PreferencesFilter_ArraySearchWithoutAttribute_Guid : FilterBase
+{
+    public Guid[] OrganizationUnitId { get; set; }
+}

--- a/tests/AutoFilterer.Tests/Environment/Models/Preferences.cs
+++ b/tests/AutoFilterer.Tests/Environment/Models/Preferences.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AutoFilterer.Attributes;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,4 +14,7 @@ public class Preferences
     public string GivenName { get; set; }
     public int SecurityLevel { get; set; }
     public int? ReadLimit { get; set; }
+
+    [ArraySearchFilter]
+    public Guid? OrganizationUnitId { get; set; }
 }


### PR DESCRIPTION
Enhanced ArraySearchFilterAttribute to handle nullable Guid properties by using extension methods for non-nullable types and value extraction. Added tests for filtering with Guid arrays without attribute and updated Preferences model to include OrganizationUnitId with ArraySearchFilter.


Closes https://github.com/enisn/AutoFilterer/issues/77